### PR TITLE
Use Client Domain for CORS

### DIFF
--- a/src/main/java/pro/arcodeh/msgoba_2002_server/config/SecurityConfig.java
+++ b/src/main/java/pro/arcodeh/msgoba_2002_server/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -34,6 +35,9 @@ import java.util.Map;
 @EnableWebSecurity
 @EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
+    @Value("${spring.clientdomain")
+    private String clientDomain;
+
     private final FirebaseTokenFilter firebaseTokenFilter;
 
     public SecurityConfig(FirebaseTokenFilter firebaseTokenFilter) {
@@ -45,7 +49,7 @@ public class SecurityConfig {
         http
                 .cors(cors -> cors.configurationSource(request -> {
                     CorsConfiguration config = new CorsConfiguration();
-                    config.addAllowedOrigin("msgoba2002.com.ng");
+                    config.addAllowedOrigin(clientDomain);
                     config.addAllowedMethod("*");
                     config.addAllowedHeader("*");
                     config.setAllowCredentials(true);


### PR DESCRIPTION
Moved client domain into environment variables for use in CORS configuration